### PR TITLE
Add month and year

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,14 +7,15 @@
 
 'use strict';
 
+var SECONDS_DAY = 864e5; // 1 * 60 * 60 * 24
+
 module.exports = function(timespan) {
   return (({
     // year  : year(),  // todo
-    // month : month(), // todo
-
+    month  : month(),
     today  : today(),
     week   : 6048e5, // 1 * 60 * 60 * 24 * 7,
-    day    : 864e5,  // 1 * 60 * 60 * 24,
+    day    : SECONDS_DAY,
     hour   : 36e5,   // 1 * 60 * 60,
     minute : 6e4,    // 1 * 60,
     second : 1e3     // 1,
@@ -24,4 +25,10 @@ module.exports = function(timespan) {
 function today() {
   var now = new Date;
   return now.getTime() - now.setHours(0, 0, 0, 0);
+}
+
+function month() {
+  var todaySeconds = today();
+  var secondsMonth = (new Date().getDate() - 1) * SECONDS_DAY;
+  return todaySeconds + secondsMonth;
 }

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ var SECONDS_DAY = 864e5; // 1 * 60 * 60 * 24
 
 module.exports = function(timespan) {
   return (({
-    // year  : year(),  // todo
+    year  : year(),
     month  : month(),
     today  : today(),
     week   : 6048e5, // 1 * 60 * 60 * 24 * 7,
@@ -31,4 +31,9 @@ function month() {
   var todaySeconds = today();
   var secondsMonth = (new Date().getDate() - 1) * SECONDS_DAY;
   return todaySeconds + secondsMonth;
+}
+
+function year() {
+  var now = new Date;
+  return now.getTime() - now.setMonth(0, 0);
 }

--- a/test.js
+++ b/test.js
@@ -27,6 +27,13 @@ describe('seconds()', function() {
     assert.equal(seconds('week'), moment.duration(1, 'week').asSeconds());
   });
 
+  it('should get the seconds for the current day, since beginning of the month.', function() {
+    var actual = seconds('month');
+    var expected = ((new Date().getDate() - 1) * seconds('day')) + seconds('today');
+
+    assert.equal(actual, expected);
+  });
+
   it('should get the seconds for the current day, since midnight.', function() {
     var todaySeconds = seconds('today');
     var now = new Date;

--- a/test.js
+++ b/test.js
@@ -27,12 +27,19 @@ describe('seconds()', function() {
     assert.equal(seconds('week'), moment.duration(1, 'week').asSeconds());
   });
 
-  it('should get the seconds for the current day, since beginning of the month.', function() {
+  it('should get the seconds since beginning of the month.', function() {
     var actual = seconds('month');
     var expected = ((new Date().getDate() - 1) * seconds('day')) + seconds('today');
 
     assert.equal(actual, expected);
   });
+
+  it('should get the seconds since beginning of the year.', function() {
+    var actual = seconds('year');
+    var now = new Date;
+    var expected = ((now.getTime() - now.setMonth(0,0)) / 1000) | 0;
+    assert.equal(actual, expected);
+  })
 
   it('should get the seconds for the current day, since midnight.', function() {
     var todaySeconds = seconds('today');


### PR DESCRIPTION
Added the functions below:
 - `month`: function to calculate seconds since beginning of the month
 - `year`: function to calculate seconds since beginning of the year